### PR TITLE
Make package dart 2 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-packages
+.dart_tool/
+.packages
 .project
 pubspec.lock
 *~
+.idea/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,8 @@
 name: lorem
 description: Lorem text generator
 
+environment:
+  sdk: '>=1.24.3 <3.0.0'
+
 dev_dependencies:
-  unittest: any
+  test: ">=0.12.30 <2.0.0"

--- a/test/lorem_test.dart
+++ b/test/lorem_test.dart
@@ -1,4 +1,4 @@
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:lorem/lorem.dart';
 
 main(){


### PR DESCRIPTION
There is currently no transition path to dart 2 for packages which depend on `lorem`. This PR retains compatibility with dart 1 while adding compatibility with dart 2.